### PR TITLE
Ensures deterministic signatures for same H/R/S.

### DIFF
--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -451,8 +451,8 @@ func (pv *ThresholdValidator) compareBlockSignatureAgainstSSC(
 		return nil, nil, stamp, err
 	}
 
-	// only differ by timestamp, okay to sign again
-	return nil, nil, stamp, nil
+	// Ensures deterministic signatures for same H/R/S.
+	return existingSignature.Signature, existingSignature.VoteExtensionSignature, stamp, nil
 }
 
 // compareBlockSignatureAgainstHRS returns a BeyondBlockError if the hrs is greater than the


### PR DESCRIPTION
This PR potentially fixes the double-singing problem for the same H/R/S.
More context


<img width="720" height="506" alt="image" src="https://github.com/user-attachments/assets/fd3b70d4-6e30-4f57-ae86-ac405d33bc89" />



A similar check exists in [Come, the privval folder](https://github.com/cometbft/cometbft/blob/d22299509a50140b74d81b113c4d78e4cf501994/privval/file.go#L455) that prevent's using new time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature handling to ensure deterministic signatures are returned for the same height, round, and step, preventing unnecessary re-signing when only the timestamp differs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->